### PR TITLE
utils.js function ftom clamp noteNum max to 128

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -27,6 +27,9 @@ module.exports = {
     ftom : function (freq){
         // Convert frequency to the mathmatically correct MIDI note number (Float Number, Not Integer)
         const noteNum = 12 * getBaseLog(2, freq/440)+69
+        if (noteNum > 128) {
+            return null;
+        }
         return noteNum
 
         function getBaseLog(x, y) {


### PR DESCRIPTION
since sometime `ftom` receive high frequency like higher than 21k Hz and it is converted into note num: 136, this is greater than midi max note num.
this PR surpress error and disable note in such situation.